### PR TITLE
Add IPAT betting bot infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,11 @@ AWS_SECRET_ACCESS_KEY=********
 AWS_DEFAULT_REGION=ap-northeast-1
 
 # AWS Secrets ManagerのシークレットID
-SECRETS_MANAGER_SECRET_ID=akatsuki/ipat/credentials
+AWS_SECRET_NAME=keiba_secret
 
-# 自動入金設定
-AUTO_DEPOSIT_AMOUNT=10000
+# S3設定（入金額設定ファイル）
+S3_CONFIG_BUCKET=akatsuki-config
+S3_DEPOSIT_CONFIG_KEY=deposit_config.json
 
 # タイムアウト設定（ミリ秒）
 TIMEOUT_MS=20000

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# AWS認証情報
+AWS_ACCESS_KEY_ID=AKIAXXXXXXXXXXXXXXXX
+AWS_SECRET_ACCESS_KEY=********
+AWS_DEFAULT_REGION=ap-northeast-1
+
+# AWS Secrets ManagerのシークレットID
+SECRETS_MANAGER_SECRET_ID=akatsuki/ipat/credentials
+
+# 自動入金設定
+AUTO_DEPOSIT_AMOUNT=10000
+
+# タイムアウト設定（ミリ秒）
+TIMEOUT_MS=20000
+
+# ヘッドレスモード（true/false）
+HEADLESS_MODE=true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,48 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# システムの依存関係をインストール
+RUN apt-get update && apt-get install -y \
+    wget \
+    gnupg \
+    ca-certificates \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libatspi2.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    xdg-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pythonパッケージをインストール
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Playwrightブラウザをインストール（chromiumのみ）
+RUN playwright install chromium
+
+# アプリケーションコードをコピー
+COPY scripts/ ./scripts/
+COPY tickets/ ./tickets/
+
+# 出力ディレクトリを作成
+RUN mkdir -p output
+
+# セキュリティのため非rootユーザーで実行
+RUN useradd -m -u 1000 bot && chown -R bot:bot /app
+USER bot
+
+CMD ["python", "scripts/bot.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+playwright==1.44.0
+pandas==2.2.2
+boto3==1.34.69
+python-dotenv==1.0.1
+asyncio==3.4.3
+aiofiles==23.2.1

--- a/scripts/bot.py
+++ b/scripts/bot.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+import os
+import asyncio
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from dotenv import load_dotenv
+from playwright.async_api import async_playwright, Page, TimeoutError
+import pandas as pd
+import boto3
+from botocore.exceptions import ClientError
+
+# 環境変数読み込み
+load_dotenv()
+
+# ロギング設定
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# 定数
+IPAT_URL = "https://www.ipat.jra.go.jp/"
+TIMEOUT_MS = int(os.environ.get('TIMEOUT_MS', '20000'))
+HEADLESS_MODE = os.environ.get('HEADLESS_MODE', 'true').lower() == 'true'
+
+
+async def get_secrets():
+    """AWS Secrets Managerから認証情報を取得"""
+    try:
+        client = boto3.client('secretsmanager', region_name=os.environ.get('AWS_DEFAULT_REGION', 'ap-northeast-1'))
+        secret_id = os.environ['SECRETS_MANAGER_SECRET_ID']
+        
+        response = client.get_secret_value(SecretId=secret_id)
+        secrets = json.loads(response['SecretString'])
+        
+        return {
+            'username': secrets['ipat_username'],
+            'password': secrets['ipat_password'],
+            'paynavi_pass': secrets['ipat_paynavi_password']
+        }
+    except ClientError as e:
+        logger.error(f"Failed to retrieve secrets: {e}")
+        raise
+    except KeyError as e:
+        logger.error(f"Missing required secret key: {e}")
+        raise
+
+
+async def login_ipat(page: Page, username: str, password: str):
+    """IPATにログイン"""
+    try:
+        logger.info("Navigating to IPAT login page...")
+        await page.goto(IPAT_URL, wait_until='networkidle', timeout=TIMEOUT_MS)
+        
+        # ログインフォームの入力
+        logger.info("Filling login form...")
+        await page.fill('input[name="userNo"]', username)
+        await page.fill('input[name="password"]', password)
+        
+        # ログインボタンクリック
+        await page.click('input[type="submit"][value="ログイン"]')
+        
+        # ログイン成功を確認
+        await page.wait_for_selector('text=マイページ', timeout=TIMEOUT_MS)
+        logger.info("Successfully logged in to IPAT")
+        
+    except TimeoutError:
+        logger.error("Login timeout - check credentials or network connection")
+        raise
+    except Exception as e:
+        logger.error(f"Login failed: {e}")
+        raise
+
+
+async def auto_deposit(page: Page, paynavi_pass: str, amount: int):
+    """PAY-NAVIを使用した自動入金"""
+    try:
+        logger.info(f"Starting auto deposit: {amount} yen")
+        
+        # 入金ページへ移動
+        await page.click('text=入金')
+        await page.wait_for_load_state('networkidle')
+        
+        # PAY-NAVI選択
+        await page.click('text=PAY-NAVI')
+        
+        # 金額入力
+        await page.fill('input[name="depositAmount"]', str(amount))
+        
+        # 暗証番号入力
+        await page.fill('input[name="payNaviPassword"]', paynavi_pass)
+        
+        # 確認画面へ
+        await page.click('input[type="submit"][value="確認"]')
+        await page.wait_for_load_state('networkidle')
+        
+        # 入金実行
+        await page.click('input[type="submit"][value="入金する"]')
+        
+        # 完了確認
+        await page.wait_for_selector('text=入金が完了しました', timeout=TIMEOUT_MS)
+        logger.info(f"Successfully deposited {amount} yen")
+        
+    except Exception as e:
+        logger.error(f"Deposit failed: {e}")
+        raise
+
+
+async def place_bet(page: Page, ticket: pd.Series):
+    """馬券購入処理"""
+    try:
+        logger.info(f"Placing bet: {ticket['race_date']} {ticket['race_name']}")
+        
+        # 購入ページへ移動
+        await page.click('text=投票')
+        await page.wait_for_load_state('networkidle')
+        
+        # レース選択
+        await page.fill('input[name="raceDate"]', ticket['race_date'])
+        await page.select_option('select[name="raceCourse"]', ticket['race_course'])
+        await page.select_option('select[name="raceNumber"]', str(ticket['race_number']))
+        
+        # 式別選択
+        await page.select_option('select[name="betType"]', ticket['bet_type'])
+        
+        # 馬番号入力
+        horse_numbers = ticket['horse_numbers'].split(',')
+        for i, horse_num in enumerate(horse_numbers):
+            await page.fill(f'input[name="horse{i+1}"]', horse_num.strip())
+        
+        # 金額入力
+        await page.fill('input[name="amount"]', str(ticket['amount']))
+        
+        # 購入確認
+        await page.click('input[type="submit"][value="投票内容確認"]')
+        await page.wait_for_load_state('networkidle')
+        
+        # 購入実行
+        await page.click('input[type="submit"][value="投票する"]')
+        
+        # 完了確認
+        await page.wait_for_selector('text=投票が完了しました', timeout=TIMEOUT_MS)
+        logger.info(f"Successfully placed bet for {ticket['race_name']}")
+        
+    except Exception as e:
+        logger.error(f"Failed to place bet: {e}")
+        raise
+
+
+async def download_results(page: Page):
+    """投票結果CSVダウンロード"""
+    try:
+        logger.info("Downloading betting results...")
+        
+        # 投票履歴ページへ
+        await page.click('text=投票履歴')
+        await page.wait_for_load_state('networkidle')
+        
+        # 本日の投票履歴を選択
+        today = datetime.now().strftime('%Y%m%d')
+        await page.fill('input[name="fromDate"]', today)
+        await page.fill('input[name="toDate"]', today)
+        await page.click('input[type="submit"][value="検索"]')
+        
+        # CSVダウンロード
+        async with page.expect_download() as download_info:
+            await page.click('text=CSVダウンロード')
+        download = await download_info.value
+        
+        # ファイル保存
+        output_path = f"output/results-{today}.csv"
+        await download.save_as(output_path)
+        logger.info(f"Results saved to: {output_path}")
+        
+        return output_path
+        
+    except Exception as e:
+        logger.error(f"Failed to download results: {e}")
+        raise
+
+
+async def main():
+    """メイン処理"""
+    try:
+        # Secrets Managerから認証情報取得
+        logger.info("Retrieving credentials from AWS Secrets Manager...")
+        secrets = await get_secrets()
+        deposit_amount = int(os.environ.get('AUTO_DEPOSIT_AMOUNT', '10000'))
+        
+        # Playwrightブラウザ起動
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(
+                headless=HEADLESS_MODE,
+                args=['--no-sandbox', '--disable-setuid-sandbox']
+            )
+            context = await browser.new_context(
+                accept_downloads=True,
+                viewport={'width': 1280, 'height': 720}
+            )
+            page = await context.new_page()
+            
+            # 1) IPATログイン
+            await login_ipat(page, secrets['username'], secrets['password'])
+            
+            # 2) 自動入金
+            await auto_deposit(page, secrets['paynavi_pass'], deposit_amount)
+            
+            # 3) tickets.csv読み込み・投票実行
+            tickets_path = Path('tickets/tickets.csv')
+            if tickets_path.exists():
+                logger.info("Reading tickets.csv...")
+                tickets_df = pd.read_csv(tickets_path)
+                logger.info(f"Found {len(tickets_df)} tickets to process")
+                
+                for idx, ticket in tickets_df.iterrows():
+                    try:
+                        await place_bet(page, ticket)
+                        # レート制限対策で少し待機
+                        await asyncio.sleep(2)
+                    except Exception as e:
+                        logger.error(f"Failed to process ticket {idx+1}: {e}")
+                        continue
+            else:
+                logger.warning("No tickets.csv found, skipping betting phase")
+            
+            # 4) 投票結果ダウンロード
+            download_path = await download_results(page)
+            logger.info(f"All processing completed. Results: {download_path}")
+            
+            await browser.close()
+            
+    except Exception as e:
+        logger.error(f"Fatal error in main process: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Set up containerized Python application for automated JRA IPAT betting operations
- Implement AWS Secrets Manager integration for secure credential management
- Add core bot functionality including login, auto-deposit, betting, and results download

## Changes
- **Docker Setup**: Created lightweight Dockerfile with python:3.11-slim base image and Playwright dependencies
- **Dependencies**: Added requirements.txt with necessary packages (playwright, pandas, boto3, etc.)
- **Main Bot Script**: Implemented `scripts/bot.py` with:
  - AWS Secrets Manager credential retrieval
  - IPAT login automation using Playwright
  - PAY-NAVI auto-deposit functionality
  - CSV-based ticket processing for automated betting
  - Betting results CSV download
- **Configuration**: Created .env.example template for environment variables
- **Project Structure**: Organized code into docker/, scripts/, tickets/, and output/ directories

## Test plan
- [ ] Build Docker image successfully
- [ ] Test AWS Secrets Manager connection with valid credentials
- [ ] Verify IPAT login functionality
- [ ] Test auto-deposit with test amount
- [ ] Validate CSV ticket parsing and betting logic
- [ ] Confirm results download functionality
- [ ] Run end-to-end test in Docker container

## Notes
Some features may require additional implementation or refinement based on actual IPAT interface behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)